### PR TITLE
Resolves Docker commands not being accessible within the `wordpress` container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wp-content/

--- a/Dockerfile.wordpress
+++ b/Dockerfile.wordpress
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     unzip \
     curl \
     tcpdump \
+    docker.io \
     && rm -rf /var/lib/apt/lists/*
 
 # Install WP-CLI
@@ -30,6 +31,9 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 # Expose ports
 EXPOSE 80 8000
+
+# Run Docker commands as root for Docker access
+USER root
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     volumes:
       - ./wp-content:/var/www/html/wp-content
       - ./logs:/var/www/html/logs
+      - /var/run/docker.sock:/var/run/docker.sock   # Add this line to mount the Docker socket
+
     depends_on:
       - db
 


### PR DESCRIPTION
#### Summary
This PR resolves the issue where Docker commands were not accessible within the `wordpress` container, causing the API to fail when trying to get container statuses. The solution allows the `wordpress` container to interact with the Docker daemon on the host and use Docker commands to check container statuses for the Vue.js frontend.
