### PR TITLE
Add support for Elasticsearch/Kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 wp-content/
 logs/
+.vscode/
+elasticsearch-data/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ This project sets up a Docker-based testing environment for WooCommerce, allowin
    - The WordPress site at `http://localhost:8080`
    - The frontend dashboard at `http://localhost:3000`
 
+5. To configure Kibana to provide a search UI for collected HTTP requests, perform the following
+   1. Ensure that at least one outbound HTTP request has been issued from the WordPress install
+      1. This can be triggered from the [Plugins > Add New Plugin](http://localhost:8080/wp-admin/plugin-install.php) page
+   2. Open the Kibana dashboard at <http://localhost:5601>
+   3. Navigate to the Stack Management page in the main sidebar
+   4. Navigate to [Kibana > Data Views](http://localhost:5601/app/management/kibana/dataViews) in the Management sidebar
+   5. Click `Create data view`
+   6. Provide a name for the data view
+   7. Set `Index pattern` to `api-calls`
+   8. Set `Timestamp field`
+   9. The data view will now be available when navigating to the [Analytics > Discover](http://localhost:5601/app/discover) page in the main sidebar
+
+<!-- Github admonition syntax - see https://github.com/orgs/community/discussions/16925 -->
+> [!NOTE]
+> In the future, the Kibana data view will be automatically created
+
 ## Frontend Dashboard
 
 The frontend dashboard provides an easy-to-use interface for managing your WooCommerce testing sandbox. It offers the following features:
@@ -72,6 +88,11 @@ To use the plugin installation feature:
 - Captures network traffic related to API calls.
 - Processes the captured data every 5 minutes.
 - Generates a CSV file (`/logs/api_calls.csv`) with information about the API calls, including the plugin that made the call, the endpoint, the HTTP method, and the timestamp.
+
+### ElasticSearch and Kibana Containers
+
+- Stores data about HTTP requests made using the WordPress HTTP API
+- Provide a frontend to browse/search captured HTTP request data
 
 ## Analyzing Results
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       WORDPRESS_ADMIN_EMAIL: admin@example.com
     volumes:
       - ./wp-content:/var/www/html/wp-content
+      - ./source-file-interceptor:/var/www/html/wp-content/plugins/source-file-interceptor
       - ./logs:/var/www/html/logs
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       WORDPRESS_ADMIN_USER: admin
       WORDPRESS_ADMIN_PASSWORD: password
       WORDPRESS_ADMIN_EMAIL: admin@example.com
+      ELASTICSEARCH_URL: http://elasticsearch:9200
     volumes:
       - ./wp-content:/var/www/html/wp-content
       - ./source-file-interceptor:/var/www/html/wp-content/plugins/source-file-interceptor
@@ -25,6 +26,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - db
+      - elasticsearch
 
   db:
     image: mariadb:10.5
@@ -57,6 +59,30 @@ services:
       - ./logs:/usr/share/nginx/html/logs
     depends_on:
       - wordpress
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.15.2
+    container_name: elasticsearch
+    restart: always
+    environment:
+      - xpack.security.enabled=false
+      - discovery.type=single-node
+    cap_add:
+      - IPC_LOCK
+    volumes:
+      - ./elasticsearch-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+  kibana:
+    container_name: kibana
+    image: docker.elastic.co/kibana/kibana:8.15.2
+    restart: always
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200    # address of elasticsearch docker container which kibana will connect
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch                                   # kibana will start when elasticsearch has started
 
 volumes:
   db_data:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,197 +1,319 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/styles.css" />
     <title>WooCommerce Sandbox Dashboard</title>
     <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
-</head>
-<body class="bg-gray-100 font-sans">
+  </head>
+
+  <body class="bg-gray-100 font-sans">
     <div id="app" class="container mx-auto p-4">
-        <h1 class="text-3xl font-semibold mb-6 text-gray-800">WooCommerce Sandbox Dashboard</h1>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div class="bg-white rounded-lg shadow-md p-6">
-                <h2 class="text-xl font-semibold mb-4 text-gray-700">Container Status</h2>
-                <div v-for="container in containerStatus" :key="container.name" class="mb-2">
-                    <span class="font-medium">{{ container.name }}:</span>
-                    <span :class="{'text-green-500': container.status === 'running', 'text-red-500': container.status !== 'running'}">
-                        {{ container.status }}
-                    </span>
-                </div>
-            </div>
-            <div class="bg-white rounded-lg shadow-md p-6">
-                <h2 class="text-xl font-semibold mb-4 text-gray-700">WordPress Status</h2>
-                <div><span class="font-medium">Version:</span> {{ wordpressStatus.version }}</div>
-                <div><span class="font-medium">WooCommerce Version:</span> {{ wordpressStatus.woocommerce_version }}</div>
-                <div class="mt-2">
-                    <a :href="wordpressStatus.url" target="_blank" class="text-blue-500 hover:underline">Visit WordPress Site</a>
-                </div>
-                <div>
-                    <a :href="wordpressStatus.admin_url" target="_blank" class="text-blue-500 hover:underline">Visit WordPress Admin</a>
-                </div>
-            </div>
+      <h1 class="text-3xl font-semibold mb-6 text-gray-800">
+        WooCommerce Sandbox Dashboard
+      </h1>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-white rounded-lg shadow-md p-6">
+          <h2 class="text-xl font-semibold mb-4 text-gray-700">
+            Container Status
+          </h2>
+          <div
+            v-for="container in containerStatus"
+            :key="container.name"
+            class="mb-2"
+          >
+            <span class="font-medium">{{ container.name }}:</span>
+            <span
+              :class="{'text-green-500': container.status === ' Running', 'text-red-500': container.status !== ' Running'}"
+            >
+              {{ container.status }}
+            </span>
+          </div>
         </div>
-        <div class="mt-6 bg-white rounded-lg shadow-md p-6">
-            <h2 class="text-xl font-semibold mb-4 text-gray-700">Installed Plugins</h2>
-            <ul class="list-disc pl-5">
-                <li v-for="plugin in installedPlugins" :key="plugin.name" class="mb-1">
-                    {{ plugin.name }} ({{ plugin.version }})
-                </li>
-            </ul>
+        <div class="bg-white rounded-lg shadow-md p-6">
+          <h2 class="text-xl font-semibold mb-4 text-gray-700">
+            WordPress Status
+          </h2>
+          <div>
+            <span class="font-medium">Version:</span> {{ wordpressStatus.version
+            }}
+          </div>
+          <div>
+            <span class="font-medium">WooCommerce Version:</span> {{
+            wordpressStatus.woocommerce_version }}
+          </div>
+          <div class="mt-2">
+            <a
+              :href="wordpressStatus.url"
+              target="_blank"
+              class="text-blue-500 hover:underline"
+              >Visit WordPress Site</a
+            >
+          </div>
+          <div>
+            <a
+              :href="wordpressStatus.admin_url"
+              target="_blank"
+              class="text-blue-500 hover:underline"
+              >Visit WordPress Admin</a
+            >
+          </div>
         </div>
-        <div class="mt-6 bg-white rounded-lg shadow-md p-6">
-            <h2 class="text-xl font-semibold mb-4 text-gray-700">Search and Install Plugins</h2>
-            <input v-model="searchQuery" @input="searchPlugins" type="text" placeholder="Search plugins..." class="mb-4 p-2 border rounded w-full">
-            <div v-if="searchError" class="text-red-500 mb-2">{{ searchError }}</div>
-            <ul class="list-disc pl-5">
-                <li v-for="plugin in searchResults" :key="plugin.slug" class="mb-2">
-                    <strong>{{ plugin.name }}</strong><br/>
-                    {{ plugin.short_description }}<br/>
-                    <button @click="installPlugin(plugin.slug)" class="ml-2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-1 px-2 rounded text-sm">
-                        Install
-                    </button>
-                </li>
-            </ul>
-            <div v-if="searchResults.length === 0 && searchQuery.length >= 3" class="text-gray-500">No results found</div>
+      </div>
+      <div class="mt-6 bg-white rounded-lg shadow-md p-6">
+        <h2 class="text-xl font-semibold mb-4 text-gray-700">
+          Installed Plugins
+        </h2>
+        <ul class="list-disc pl-5">
+          <li
+            v-for="plugin in installedPlugins"
+            :key="plugin.name"
+            class="mb-1"
+          >
+            {{ plugin.name }} ({{ plugin.version }})
+          </li>
+        </ul>
+      </div>
+      <div class="mt-6 bg-white rounded-lg shadow-md p-6">
+        <h2 class="text-xl font-semibold mb-4 text-gray-700">
+          Search and Install Plugins
+        </h2>
+        <input
+          v-model="searchQuery"
+          @input="searchPlugins"
+          type="text"
+          placeholder="Search plugins..."
+          class="mb-4 p-2 border rounded w-full"
+        />
+        <div v-if="loading" class="text-gray-500 mb-4">Loading...</div>
+        <div v-if="searchError" class="text-red-500 mb-2">
+          {{ searchError }}
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
-            <div class="bg-white rounded-lg shadow-md p-6">
-                <h2 class="text-xl font-semibold mb-4 text-gray-700">Install Plugins from CSV</h2>
-                <input type="file" @change="handleFileUpload" class="mb-4 p-2 border rounded" accept=".csv">
-                <button @click="installPlugins" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
-                    Install Plugins
-                </button>
-            </div>
-            <div class="bg-white rounded-lg shadow-md p-6">
-                <h2 class="text-xl font-semibold mb-4 text-gray-700">API Calls</h2>
-                <a href="logs/api_calls.csv" target="_blank" class="text-blue-500 hover:underline">Download CSV</a>
-            </div>  
+        <ul class="list-disc pl-5">
+          <li v-for="plugin in searchResults" :key="plugin.slug" class="mb-2">
+            <strong>{{ plugin.name }}</strong><br />
+            {{ plugin.short_description }}<br />
+            <button
+              @click="installPlugin(plugin.slug)"
+              :disabled="isInstalling(plugin.slug)"
+              class="ml-2 bg-blue-500 hover:bg-blue-600 text-white font-bold py-1 px-2 rounded text-sm flex items-center"
+            >
+              <span v-if="isInstalling(plugin.slug)" class="loader mr-2"></span>
+              <span v-else>Install</span>
+            </button>
+          </li>
+        </ul>
+        <div
+          v-if="searchResults.length === 0 && searchQuery.length >= 3 && !loading"
+          class="text-gray-500"
+        >
+          No results found
         </div>
-        <div class="mt-6 bg-white rounded-lg shadow-md p-6">
-            <h2 class="text-xl font-semibold mb-4 text-gray-700">Debug Information</h2>
-            <pre class="bg-gray-100 p-2 rounded">{{ debugInfo }}</pre>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
+        <div class="bg-white rounded-lg shadow-md p-6">
+          <h2 class="text-xl font-semibold mb-4 text-gray-700">
+            Install Plugins from CSV
+          </h2>
+          <input
+            type="file"
+            @change="handleFileUpload"
+            class="mb-4 p-2 border rounded"
+            accept=".csv"
+          />
+          <button
+            @click="installPlugins"
+            class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+          >
+            Install Plugins
+          </button>
         </div>
+        <div class="bg-white rounded-lg shadow-md p-6">
+          <h2 class="text-xl font-semibold mb-4 text-gray-700">API Calls</h2>
+          <a
+            href="logs/api_calls.csv"
+            target="_blank"
+            class="text-blue-500 hover:underline"
+            >Download CSV</a
+          >
+        </div>
+      </div>
+      <div class="mt-6 bg-white rounded-lg shadow-md p-6">
+        <h2 class="text-xl font-semibold mb-4 text-gray-700">
+          Debug Information
+        </h2>
+        <pre class="bg-gray-100 p-2 rounded">{{ debugInfo }}</pre>
+      </div>
     </div>
 
     <script>
-        const { createApp, ref, onMounted, watch } = Vue;
+      const { createApp, ref, onMounted, watch } = Vue;
 
-        createApp({
-            setup() {
-                const containerStatus = ref([]);
-                const wordpressStatus = ref({ version: '', woocommerce_version: '', url: '', admin_url: '' });
-                const installedPlugins = ref([]);
-                const selectedFile = ref(null);
-                const searchQuery = ref('');
-                const searchResults = ref([]);
-                const searchError = ref('');
-                const debugInfo = ref({});
+      createApp({
+        setup() {
+          const containerStatus = ref([]);
+          const wordpressStatus = ref({
+            version: "",
+            woocommerce_version: "",
+            url: "",
+            admin_url: "",
+          });
+          const installedPlugins = ref([]);
+          const selectedFile = ref(null);
+          const searchQuery = ref("");
+          const searchResults = ref([]);
+          const searchError = ref("");
+          const loading = ref(false);
+          const loadingPlugins = ref([]); // Add state to track plugins being installed
+          const debugInfo = ref({});
 
-                const fetchStatus = async () => {
-                    try {
-                        const response = await axios.get('http://localhost:8000/api.php');
-                        containerStatus.value = response.data.containers;
-                        wordpressStatus.value = response.data.wordpress;
-                        installedPlugins.value = response.data.plugins;
-                        debugInfo.value = { ...debugInfo.value, statusResponse: response.data };
-                    } catch (error) {
-                        console.error('Error fetching status:', error);
-                        debugInfo.value = { ...debugInfo.value, statusError: error.message };
-                    }
-                };
-
-                const handleFileUpload = (event) => {
-                    selectedFile.value = event.target.files[0];
-                };
-
-                const installPlugins = async () => {
-                    if (!selectedFile.value) {
-                        alert('Please select a CSV file first.');
-                        return;
-                    }
-                    const formData = new FormData();
-                    formData.append('file', selectedFile.value);
-                    try {
-                        const response = await axios.post('http://localhost:8000/install_plugins.php', formData, {
-                            headers: {
-                                'Content-Type': 'multipart/form-data'
-                            }
-                        });
-                        alert(response.data.message);
-                        fetchStatus();
-                    } catch (error) {
-                        console.error('Error installing plugins:', error);
-                        alert('Error installing plugins. Please check the logs for details.');
-                    }
-                };
-
-                const debounce = (func, wait) => {
-                    let timeout;
-                    return (...args) => {
-                        clearTimeout(timeout);
-                        timeout = setTimeout(() => func.apply(this, args), wait);
-                    };
-                };
-
-                const searchPlugins = debounce(async () => {
-                    if (searchQuery.value.length < 3) {
-                        searchResults.value = [];
-                        return;
-                    }
-                    try {
-                        debugInfo.value = { ...debugInfo.value, searchQuery: searchQuery.value };
-                        const response = await axios.get(`http://localhost:8000/api.php?search_plugin=${searchQuery.value}`);
-                        searchResults.value = response.data;
-                        searchError.value = '';
-                        debugInfo.value = { ...debugInfo.value, searchResponse: response.data };
-                    } catch (error) {
-                        console.error('Error searching plugins:', error);
-                        searchError.value = 'Error searching plugins. Please try again.';
-                        debugInfo.value = { ...debugInfo.value, searchError: error.message };
-                    }
-                }, 300);
-
-                const installPlugin = async (pluginSlug) => {
-                    try {
-                        const response = await axios.get(`http://localhost:8000/api.php?plugin_to_install=${pluginSlug}`);
-                        alert(response.data.message);
-                        fetchStatus();
-                    } catch (error) {
-                        console.error('Error installing plugin:', error);
-                        alert('Error installing plugin. Please check the logs for details.');
-                    }
-                };
-
-                onMounted(() => {
-                    fetchStatus();
-                    setInterval(fetchStatus, 30000); // Refresh every 30 seconds
-                });
-
-                watch(searchQuery, () => {
-                    if (searchQuery.value.length >= 3) {
-                        searchPlugins();
-                    } else {
-                        searchResults.value = [];
-                    }
-                });
-
-                return {
-                    containerStatus,
-                    wordpressStatus,
-                    installedPlugins,
-                    handleFileUpload,
-                    installPlugins,
-                    searchQuery,
-                    searchResults,
-                    searchPlugins,
-                    installPlugin,
-                    searchError,
-                    debugInfo
-                };
+          const fetchStatus = async () => {
+            try {
+              const response = await axios.get("http://localhost:8000/api.php");
+              containerStatus.value = response.data.containers;
+              wordpressStatus.value = response.data.wordpress;
+              installedPlugins.value = response.data.plugins;
+              debugInfo.value = {
+                ...debugInfo.value,
+                statusResponse: response.data,
+              };
+            } catch (error) {
+              console.error("Error fetching status:", error);
+              debugInfo.value = {
+                ...debugInfo.value,
+                statusError: error.message,
+              };
             }
-        }).mount('#app');
+          };
+
+          const handleFileUpload = (event) => {
+            selectedFile.value = event.target.files[0];
+          };
+
+          const installPlugins = async () => {
+            if (!selectedFile.value) {
+              alert("Please select a CSV file first.");
+              return;
+            }
+            const formData = new FormData();
+            formData.append("file", selectedFile.value);
+            try {
+              const response = await axios.post(
+                "http://localhost:8000/install_plugins.php",
+                formData,
+                {
+                  headers: {
+                    "Content-Type": "multipart/form-data",
+                  },
+                }
+              );
+              alert(response.data.message);
+              fetchStatus();
+            } catch (error) {
+              console.error("Error installing plugins:", error);
+              alert(
+                "Error installing plugins. Please check the logs for details."
+              );
+            }
+          };
+
+          const debounce = (func, wait) => {
+            let timeout;
+            return (...args) => {
+              clearTimeout(timeout);
+              timeout = setTimeout(() => func.apply(this, args), wait);
+            };
+          };
+
+          const searchPlugins = debounce(async () => {
+            if (searchQuery.value.length < 3) {
+              searchResults.value = [];
+              return;
+            }
+            loading.value = true;
+            try {
+              debugInfo.value = {
+                ...debugInfo.value,
+                searchQuery: searchQuery.value,
+              };
+              const response = await axios.get(
+                `http://localhost:8000/api.php?search_plugin=${searchQuery.value}`
+              );
+              searchResults.value = response.data;
+              searchError.value = "";
+              debugInfo.value = {
+                ...debugInfo.value,
+                searchResponse: response.data,
+              };
+            } catch (error) {
+              console.error("Error searching plugins:", error);
+              searchError.value = "Error searching plugins. Please try again.";
+              debugInfo.value = {
+                ...debugInfo.value,
+                searchError: error.message,
+              };
+            } finally {
+              loading.value = false;
+            }
+          }, 300);
+
+          const installPlugin = async (pluginSlug) => {
+            loadingPlugins.value.push(pluginSlug); // Add the plugin slug to the loadingPlugins array
+            try {
+              const response = await axios.get(
+                `http://localhost:8000/api.php?plugin_to_install=${pluginSlug}`
+              );
+              alert(response.data.message);
+              fetchStatus();
+            } catch (error) {
+              console.error("Error installing plugin:", error);
+              alert(
+                "Error installing plugin. Please check the logs for details."
+              );
+            } finally {
+              // Remove the plugin slug from the loadingPlugins array
+              loadingPlugins.value = loadingPlugins.value.filter(
+                (slug) => slug !== pluginSlug
+              );
+            }
+          };
+
+          // Helper function to check if a plugin is currently being installed
+          const isInstalling = (pluginSlug) =>
+            loadingPlugins.value.includes(pluginSlug);
+
+          onMounted(() => {
+            fetchStatus();
+            setInterval(fetchStatus, 30000); // Refresh every 30 seconds
+          });
+
+          watch(searchQuery, () => {
+            if (searchQuery.value.length >= 3) {
+              searchPlugins();
+            } else {
+              searchResults.value = [];
+            }
+          });
+
+          return {
+            containerStatus,
+            wordpressStatus,
+            installedPlugins,
+            searchQuery,
+            searchResults,
+            searchPlugins,
+            installPlugin,
+            searchError,
+            loading,
+            loadingPlugins, // Return the loading state to the template
+            isInstalling, // Return the isInstalling helper function to the template
+            debugInfo,
+          };
+        },
+      }).mount("#app");
     </script>
-</body>
+  </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,6 +139,13 @@
             class="text-blue-500 hover:underline"
             >Download CSV</a
           >
+          <br/>
+          <a
+            href="http://localhost:5601"
+            target="_blank"
+            class="text-blue-500 hover:underline"
+            >Kibana dashboard</a
+          >
         </div>
       </div>
       <div class="mt-6 bg-white rounded-lg shadow-md p-6">

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,17 @@
+.loader {
+  border: 2px solid #f3f3f3;
+  border-top: 2px solid #3498db;
+  border-radius: 50%;
+  width: 14px;
+  height: 14px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -32,6 +32,11 @@ if [ -f "/var/www/html/plugins.csv" ]; then
     /usr/local/bin/install_plugins.sh /var/www/html/plugins.csv
 fi
 
+if [ -f "/var/www/html/wp-content/plugins/source-file-interceptor" ]; then
+    echo "Enabling WP HTTP interceptor"
+    wp plugin activate source-file-interceptor
+fi
+
 # Start monitoring API calls in the background
 /usr/local/bin/monitor_api_calls.sh &
 

--- a/scripts/monitor_api_calls.sh
+++ b/scripts/monitor_api_calls.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Directory to store tcpdump output
-TCPDUMP_DIR="/var/www/html/logs/tcpdump_output"
+TCPDUMP_DIR="/var/www/html/logs"
 mkdir -p "$TCPDUMP_DIR"
 
 # Start tcpdump to capture HTTP traffic

--- a/scripts/testtools_entrypoint.sh
+++ b/scripts/testtools_entrypoint.sh
@@ -4,6 +4,6 @@
 while true; do
     sleep 60
     echo "Processing API calls..."
-    python /usr/local/bin/process_api_calls.py /logs/tcpdump_output/api_calls.pcap /logs/api_calls.csv
+    python /usr/local/bin/process_api_calls.py /logs/api_calls.pcap /logs/api_calls.csv
     echo "API calls processed and saved to /logs/api_calls.csv"
 done

--- a/source-file-interceptor/LICENSE.txt
+++ b/source-file-interceptor/LICENSE.txt
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/source-file-interceptor/README.txt
+++ b/source-file-interceptor/README.txt
@@ -1,0 +1,114 @@
+=== Plugin Name ===
+Contributors: (this should be a list of wordpress.org userid's)
+Donate link: https://example.com/
+Tags: comments, spam
+Requires at least: 3.0.1
+Tested up to: 3.4
+Stable tag: 4.3
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+
+== Description ==
+
+This is the long description.  No limit, and you can use Markdown (as well as in the following sections).
+
+For backwards compatibility, if this section is missing, the full length of the short description will be used, and
+Markdown parsed.
+
+A few notes about the sections above:
+
+*   "Contributors" is a comma separated list of wp.org/wp-plugins.org usernames
+*   "Tags" is a comma separated list of tags that apply to the plugin
+*   "Requires at least" is the lowest version that the plugin will work on
+*   "Tested up to" is the highest version that you've *successfully used to test the plugin*. Note that it might work on
+higher versions... this is just the highest one you've verified.
+*   Stable tag should indicate the Subversion "tag" of the latest stable version, or "trunk," if you use `/trunk/` for
+stable.
+
+    Note that the `readme.txt` of the stable tag is the one that is considered the defining one for the plugin, so
+if the `/trunk/readme.txt` file says that the stable tag is `4.3`, then it is `/tags/4.3/readme.txt` that'll be used
+for displaying information about the plugin.  In this situation, the only thing considered from the trunk `readme.txt`
+is the stable tag pointer.  Thus, if you develop in trunk, you can update the trunk `readme.txt` to reflect changes in
+your in-development version, without having that information incorrectly disclosed about the current stable version
+that lacks those changes -- as long as the trunk's `readme.txt` points to the correct stable tag.
+
+    If no stable tag is provided, it is assumed that trunk is stable, but you should specify "trunk" if that's where
+you put the stable version, in order to eliminate any doubt.
+
+== Installation ==
+
+This section describes how to install the plugin and get it working.
+
+e.g.
+
+1. Upload `source-file-interceptor.php` to the `/wp-content/plugins/` directory
+1. Activate the plugin through the 'Plugins' menu in WordPress
+1. Place `<?php do_action('plugin_name_hook'); ?>` in your templates
+
+== Frequently Asked Questions ==
+
+= A question that someone might have =
+
+An answer to that question.
+
+= What about foo bar? =
+
+Answer to foo bar dilemma.
+
+== Screenshots ==
+
+1. This screen shot description corresponds to screenshot-1.(png|jpg|jpeg|gif). Note that the screenshot is taken from
+the /assets directory or the directory that contains the stable readme.txt (tags or trunk). Screenshots in the /assets
+directory take precedence. For example, `/assets/screenshot-1.png` would win over `/tags/4.3/screenshot-1.png`
+(or jpg, jpeg, gif).
+2. This is the second screen shot
+
+== Changelog ==
+
+= 1.0 =
+* A change since the previous version.
+* Another change.
+
+= 0.5 =
+* List versions from most recent at top to oldest at bottom.
+
+== Upgrade Notice ==
+
+= 1.0 =
+Upgrade notices describe the reason a user should upgrade.  No more than 300 characters.
+
+= 0.5 =
+This version fixes a security related bug.  Upgrade immediately.
+
+== Arbitrary section ==
+
+You may provide arbitrary sections, in the same format as the ones above.  This may be of use for extremely complicated
+plugins where more information needs to be conveyed that doesn't fit into the categories of "description" or
+"installation."  Arbitrary sections will be shown below the built-in sections outlined above.
+
+== A brief Markdown Example ==
+
+Ordered list:
+
+1. Some feature
+1. Another feature
+1. Something else about the plugin
+
+Unordered list:
+
+* something
+* something else
+* third thing
+
+Here's a link to [WordPress](http://wordpress.org/ "Your favorite software") and one to [Markdown's Syntax Documentation][markdown syntax].
+Titles are optional, naturally.
+
+[markdown syntax]: http://daringfireball.net/projects/markdown/syntax
+            "Markdown is what the parser uses to process much of the readme file"
+
+Markdown uses email style notation for blockquotes and I've been told:
+> Asterisks for *emphasis*. Double it up  for **strong**.
+
+`<?php code(); // goes in backticks ?>`

--- a/source-file-interceptor/admin/class-source-file-interceptor-admin.php
+++ b/source-file-interceptor/admin/class-source-file-interceptor-admin.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * The admin-specific functionality of the plugin.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/admin
+ */
+
+/**
+ * The admin-specific functionality of the plugin.
+ *
+ * Defines the plugin name, version, and two examples hooks for how to
+ * enqueue the admin-specific stylesheet and JavaScript.
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/admin
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_Admin {
+
+	/**
+	 * The ID of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $plugin_name    The ID of this plugin.
+	 */
+	private $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $version    The current version of this plugin.
+	 */
+	private $version;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since    1.0.0
+	 * @param      string    $plugin_name       The name of this plugin.
+	 * @param      string    $version    The version of this plugin.
+	 */
+	public function __construct( $plugin_name, $version ) {
+
+		$this->plugin_name = $plugin_name;
+		$this->version = $version;
+
+	}
+
+	/**
+	 * Register the stylesheets for the admin area.
+	 *
+	 * @since    1.0.0
+	 */
+	public function enqueue_styles() {
+
+		/**
+		 * This function is provided for demonstration purposes only.
+		 *
+		 * An instance of this class should be passed to the run() function
+		 * defined in Source_File_Interceptor_Loader as all of the hooks are defined
+		 * in that particular class.
+		 *
+		 * The Source_File_Interceptor_Loader will then create the relationship
+		 * between the defined hooks and the functions defined in this
+		 * class.
+		 */
+
+		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/source-file-interceptor-admin.css', array(), $this->version, 'all' );
+
+	}
+
+	/**
+	 * Register the JavaScript for the admin area.
+	 *
+	 * @since    1.0.0
+	 */
+	public function enqueue_scripts() {
+
+		/**
+		 * This function is provided for demonstration purposes only.
+		 *
+		 * An instance of this class should be passed to the run() function
+		 * defined in Source_File_Interceptor_Loader as all of the hooks are defined
+		 * in that particular class.
+		 *
+		 * The Source_File_Interceptor_Loader will then create the relationship
+		 * between the defined hooks and the functions defined in this
+		 * class.
+		 */
+
+		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/source-file-interceptor-admin.js', array( 'jquery' ), $this->version, false );
+
+	}
+
+}

--- a/source-file-interceptor/admin/css/source-file-interceptor-admin.css
+++ b/source-file-interceptor/admin/css/source-file-interceptor-admin.css
@@ -1,0 +1,4 @@
+/**
+ * All of the CSS for your admin-specific functionality should be
+ * included in this file.
+ */

--- a/source-file-interceptor/admin/index.php
+++ b/source-file-interceptor/admin/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/source-file-interceptor/admin/js/source-file-interceptor-admin.js
+++ b/source-file-interceptor/admin/js/source-file-interceptor-admin.js
@@ -1,0 +1,32 @@
+(function( $ ) {
+	'use strict';
+
+	/**
+	 * All of the code for your admin-facing JavaScript source
+	 * should reside in this file.
+	 *
+	 * Note: It has been assumed you will write jQuery code here, so the
+	 * $ function reference has been prepared for usage within the scope
+	 * of this function.
+	 *
+	 * This enables you to define handlers, for when the DOM is ready:
+	 *
+	 * $(function() {
+	 *
+	 * });
+	 *
+	 * When the window is loaded:
+	 *
+	 * $( window ).load(function() {
+	 *
+	 * });
+	 *
+	 * ...and/or other possibilities.
+	 *
+	 * Ideally, it is not considered best practise to attach more than a
+	 * single DOM-ready or window-load handler for a particular page.
+	 * Although scripts in the WordPress core, Plugins and Themes may be
+	 * practising this, we should strive to set a better example in our own work.
+	 */
+
+})( jQuery );

--- a/source-file-interceptor/admin/partials/source-file-interceptor-admin-display.php
+++ b/source-file-interceptor/admin/partials/source-file-interceptor-admin-display.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Provide a admin area view for the plugin
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/admin/partials
+ */
+?>
+
+<!-- This file should primarily consist of HTML with a little bit of PHP. -->

--- a/source-file-interceptor/includes/class-source-file-interceptor-activator.php
+++ b/source-file-interceptor/includes/class-source-file-interceptor-activator.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Fired during plugin activation
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ */
+
+/**
+ * Fired during plugin activation.
+ *
+ * This class defines all code necessary to run during the plugin's activation.
+ *
+ * @since      1.0.0
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_Activator {
+
+	/**
+	 * Short Description. (use period)
+	 *
+	 * Long Description.
+	 *
+	 * @since    1.0.0
+	 */
+	public static function activate() {
+
+	}
+
+}

--- a/source-file-interceptor/includes/class-source-file-interceptor-deactivator.php
+++ b/source-file-interceptor/includes/class-source-file-interceptor-deactivator.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Fired during plugin deactivation
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ */
+
+/**
+ * Fired during plugin deactivation.
+ *
+ * This class defines all code necessary to run during the plugin's deactivation.
+ *
+ * @since      1.0.0
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_Deactivator {
+
+	/**
+	 * Short Description. (use period)
+	 *
+	 * Long Description.
+	 *
+	 * @since    1.0.0
+	 */
+	public static function deactivate() {
+
+	}
+
+}

--- a/source-file-interceptor/includes/class-source-file-interceptor-i18n.php
+++ b/source-file-interceptor/includes/class-source-file-interceptor-i18n.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Define the internationalization functionality
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ */
+
+/**
+ * Define the internationalization functionality.
+ *
+ * Loads and defines the internationalization files for this plugin
+ * so that it is ready for translation.
+ *
+ * @since      1.0.0
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_i18n {
+
+
+	/**
+	 * Load the plugin text domain for translation.
+	 *
+	 * @since    1.0.0
+	 */
+	public function load_plugin_textdomain() {
+
+		load_plugin_textdomain(
+			'source-file-interceptor',
+			false,
+			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+		);
+
+	}
+
+
+
+}

--- a/source-file-interceptor/includes/class-source-file-interceptor-loader.php
+++ b/source-file-interceptor/includes/class-source-file-interceptor-loader.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Register all actions and filters for the plugin
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ */
+
+/**
+ * Register all actions and filters for the plugin.
+ *
+ * Maintain a list of all hooks that are registered throughout
+ * the plugin, and register them with the WordPress API. Call the
+ * run function to execute the list of actions and filters.
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_Loader {
+
+	/**
+	 * The array of actions registered with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      array    $actions    The actions registered with WordPress to fire when the plugin loads.
+	 */
+	protected $actions;
+
+	/**
+	 * The array of filters registered with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      array    $filters    The filters registered with WordPress to fire when the plugin loads.
+	 */
+	protected $filters;
+
+	/**
+	 * Initialize the collections used to maintain the actions and filters.
+	 *
+	 * @since    1.0.0
+	 */
+	public function __construct() {
+
+		$this->actions = array();
+		$this->filters = array();
+
+	}
+
+	/**
+	 * Add a new action to the collection to be registered with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @param    string               $hook             The name of the WordPress action that is being registered.
+	 * @param    object               $component        A reference to the instance of the object on which the action is defined.
+	 * @param    string               $callback         The name of the function definition on the $component.
+	 * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+	 * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1.
+	 */
+	public function add_action( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+		$this->actions = $this->add( $this->actions, $hook, $component, $callback, $priority, $accepted_args );
+	}
+
+	/**
+	 * Add a new filter to the collection to be registered with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @param    string               $hook             The name of the WordPress filter that is being registered.
+	 * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param    string               $callback         The name of the function definition on the $component.
+	 * @param    int                  $priority         Optional. The priority at which the function should be fired. Default is 10.
+	 * @param    int                  $accepted_args    Optional. The number of arguments that should be passed to the $callback. Default is 1
+	 */
+	public function add_filter( $hook, $component, $callback, $priority = 10, $accepted_args = 1 ) {
+		$this->filters = $this->add( $this->filters, $hook, $component, $callback, $priority, $accepted_args );
+	}
+
+	/**
+	 * A utility function that is used to register the actions and hooks into a single
+	 * collection.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @param    array                $hooks            The collection of hooks that is being registered (that is, actions or filters).
+	 * @param    string               $hook             The name of the WordPress filter that is being registered.
+	 * @param    object               $component        A reference to the instance of the object on which the filter is defined.
+	 * @param    string               $callback         The name of the function definition on the $component.
+	 * @param    int                  $priority         The priority at which the function should be fired.
+	 * @param    int                  $accepted_args    The number of arguments that should be passed to the $callback.
+	 * @return   array                                  The collection of actions and filters registered with WordPress.
+	 */
+	private function add( $hooks, $hook, $component, $callback, $priority, $accepted_args ) {
+
+		$hooks[] = array(
+			'hook'          => $hook,
+			'component'     => $component,
+			'callback'      => $callback,
+			'priority'      => $priority,
+			'accepted_args' => $accepted_args
+		);
+
+		return $hooks;
+
+	}
+
+	/**
+	 * Register the filters and actions with WordPress.
+	 *
+	 * @since    1.0.0
+	 */
+	public function run() {
+
+		foreach ( $this->filters as $hook ) {
+			add_filter( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+		}
+
+		foreach ( $this->actions as $hook ) {
+			add_action( $hook['hook'], array( $hook['component'], $hook['callback'] ), $hook['priority'], $hook['accepted_args'] );
+		}
+
+	}
+
+}

--- a/source-file-interceptor/includes/class-source-file-interceptor.php
+++ b/source-file-interceptor/includes/class-source-file-interceptor.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * The file that defines the core plugin class
+ *
+ * A class definition that includes attributes and functions used across both the
+ * public-facing side of the site and the admin area.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ */
+
+/**
+ * The core plugin class.
+ *
+ * This is used to define internationalization, admin-specific hooks, and
+ * public-facing site hooks.
+ *
+ * Also maintains the unique identifier of this plugin as well as the current
+ * version of the plugin.
+ *
+ * @since      1.0.0
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/includes
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor {
+
+	/**
+	 * The loader that's responsible for maintaining and registering all hooks that power
+	 * the plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      Source_File_Interceptor_Loader    $loader    Maintains and registers all hooks for the plugin.
+	 */
+	protected $loader;
+
+	/**
+	 * The unique identifier of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $plugin_name    The string used to uniquely identify this plugin.
+	 */
+	protected $plugin_name;
+
+	/**
+	 * The current version of the plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   protected
+	 * @var      string    $version    The current version of the plugin.
+	 */
+	protected $version;
+
+	/**
+	 * Define the core functionality of the plugin.
+	 *
+	 * Set the plugin name and the plugin version that can be used throughout the plugin.
+	 * Load the dependencies, define the locale, and set the hooks for the admin area and
+	 * the public-facing side of the site.
+	 *
+	 * @since    1.0.0
+	 */
+	public function __construct() {
+		if ( defined( 'SOURCE_FILE_INTERCEPTOR_VERSION' ) ) {
+			$this->version = SOURCE_FILE_INTERCEPTOR_VERSION;
+		} else {
+			$this->version = '1.0.0';
+		}
+		$this->plugin_name = 'source-file-interceptor';
+
+		$this->load_dependencies();
+		$this->set_locale();
+		$this->define_admin_hooks();
+		$this->define_public_hooks();
+
+	}
+
+	/**
+	 * Load the required dependencies for this plugin.
+	 *
+	 * Include the following files that make up the plugin:
+	 *
+	 * - Source_File_Interceptor_Loader. Orchestrates the hooks of the plugin.
+	 * - Source_File_Interceptor_i18n. Defines internationalization functionality.
+	 * - Source_File_Interceptor_Admin. Defines all hooks for the admin area.
+	 * - Source_File_Interceptor_Public. Defines all hooks for the public side of the site.
+	 *
+	 * Create an instance of the loader which will be used to register the hooks
+	 * with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function load_dependencies() {
+
+		/**
+		 * The class responsible for orchestrating the actions and filters of the
+		 * core plugin.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-source-file-interceptor-loader.php';
+
+		/**
+		 * The class responsible for defining internationalization functionality
+		 * of the plugin.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-source-file-interceptor-i18n.php';
+
+		/**
+		 * The class responsible for defining all actions that occur in the admin area.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'admin/class-source-file-interceptor-admin.php';
+
+		/**
+		 * The class responsible for defining all actions that occur in the public-facing
+		 * side of the site.
+		 */
+		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-source-file-interceptor-public.php';
+
+		$this->loader = new Source_File_Interceptor_Loader();
+
+	}
+
+	/**
+	 * Define the locale for this plugin for internationalization.
+	 *
+	 * Uses the Source_File_Interceptor_i18n class in order to set the domain and to register the hook
+	 * with WordPress.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function set_locale() {
+
+		$plugin_i18n = new Source_File_Interceptor_i18n();
+
+		$this->loader->add_action( 'plugins_loaded', $plugin_i18n, 'load_plugin_textdomain' );
+
+	}
+
+	/**
+	 * Register all of the hooks related to the admin area functionality
+	 * of the plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function define_admin_hooks() {
+
+		$plugin_admin = new Source_File_Interceptor_Admin( $this->get_plugin_name(), $this->get_version() );
+
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
+		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+
+	}
+
+	/**
+	 * Register all of the hooks related to the public-facing functionality
+	 * of the plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 */
+	private function define_public_hooks() {
+
+		$plugin_public = new Source_File_Interceptor_Public( $this->get_plugin_name(), $this->get_version() );
+
+		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
+		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
+
+	}
+
+	/**
+	 * Run the loader to execute all of the hooks with WordPress.
+	 *
+	 * @since    1.0.0
+	 */
+	public function run() {
+		$this->loader->run();
+	}
+
+	/**
+	 * The name of the plugin used to uniquely identify it within the context of
+	 * WordPress and to define internationalization functionality.
+	 *
+	 * @since     1.0.0
+	 * @return    string    The name of the plugin.
+	 */
+	public function get_plugin_name() {
+		return $this->plugin_name;
+	}
+
+	/**
+	 * The reference to the class that orchestrates the hooks with the plugin.
+	 *
+	 * @since     1.0.0
+	 * @return    Source_File_Interceptor_Loader    Orchestrates the hooks of the plugin.
+	 */
+	public function get_loader() {
+		return $this->loader;
+	}
+
+	/**
+	 * Retrieve the version number of the plugin.
+	 *
+	 * @since     1.0.0
+	 * @return    string    The version number of the plugin.
+	 */
+	public function get_version() {
+		return $this->version;
+	}
+
+}

--- a/source-file-interceptor/includes/index.php
+++ b/source-file-interceptor/includes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/source-file-interceptor/index.php
+++ b/source-file-interceptor/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/source-file-interceptor/public/class-source-file-interceptor-public.php
+++ b/source-file-interceptor/public/class-source-file-interceptor-public.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * The public-facing functionality of the plugin.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/public
+ */
+
+/**
+ * The public-facing functionality of the plugin.
+ *
+ * Defines the plugin name, version, and two examples hooks for how to
+ * enqueue the public-facing stylesheet and JavaScript.
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/public
+ * @author     James O'Brien <james.obrien@wpengine.com>
+ */
+class Source_File_Interceptor_Public {
+
+	/**
+	 * The ID of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $plugin_name    The ID of this plugin.
+	 */
+	private $plugin_name;
+
+	/**
+	 * The version of this plugin.
+	 *
+	 * @since    1.0.0
+	 * @access   private
+	 * @var      string    $version    The current version of this plugin.
+	 */
+	private $version;
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since    1.0.0
+	 * @param      string    $plugin_name       The name of the plugin.
+	 * @param      string    $version    The version of this plugin.
+	 */
+	public function __construct( $plugin_name, $version ) {
+
+		$this->plugin_name = $plugin_name;
+		$this->version = $version;
+
+	}
+
+	/**
+	 * Register the stylesheets for the public-facing side of the site.
+	 *
+	 * @since    1.0.0
+	 */
+	public function enqueue_styles() {
+
+		/**
+		 * This function is provided for demonstration purposes only.
+		 *
+		 * An instance of this class should be passed to the run() function
+		 * defined in Source_File_Interceptor_Loader as all of the hooks are defined
+		 * in that particular class.
+		 *
+		 * The Source_File_Interceptor_Loader will then create the relationship
+		 * between the defined hooks and the functions defined in this
+		 * class.
+		 */
+
+		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/source-file-interceptor-public.css', array(), $this->version, 'all' );
+
+	}
+
+	/**
+	 * Register the JavaScript for the public-facing side of the site.
+	 *
+	 * @since    1.0.0
+	 */
+	public function enqueue_scripts() {
+
+		/**
+		 * This function is provided for demonstration purposes only.
+		 *
+		 * An instance of this class should be passed to the run() function
+		 * defined in Source_File_Interceptor_Loader as all of the hooks are defined
+		 * in that particular class.
+		 *
+		 * The Source_File_Interceptor_Loader will then create the relationship
+		 * between the defined hooks and the functions defined in this
+		 * class.
+		 */
+
+		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/source-file-interceptor-public.js', array( 'jquery' ), $this->version, false );
+
+	}
+
+}

--- a/source-file-interceptor/public/css/source-file-interceptor-public.css
+++ b/source-file-interceptor/public/css/source-file-interceptor-public.css
@@ -1,0 +1,4 @@
+/**
+ * All of the CSS for your public-facing functionality should be
+ * included in this file.
+ */

--- a/source-file-interceptor/public/index.php
+++ b/source-file-interceptor/public/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/source-file-interceptor/public/js/source-file-interceptor-public.js
+++ b/source-file-interceptor/public/js/source-file-interceptor-public.js
@@ -1,0 +1,32 @@
+(function( $ ) {
+	'use strict';
+
+	/**
+	 * All of the code for your public-facing JavaScript source
+	 * should reside in this file.
+	 *
+	 * Note: It has been assumed you will write jQuery code here, so the
+	 * $ function reference has been prepared for usage within the scope
+	 * of this function.
+	 *
+	 * This enables you to define handlers, for when the DOM is ready:
+	 *
+	 * $(function() {
+	 *
+	 * });
+	 *
+	 * When the window is loaded:
+	 *
+	 * $( window ).load(function() {
+	 *
+	 * });
+	 *
+	 * ...and/or other possibilities.
+	 *
+	 * Ideally, it is not considered best practise to attach more than a
+	 * single DOM-ready or window-load handler for a particular page.
+	 * Although scripts in the WordPress core, Plugins and Themes may be
+	 * practising this, we should strive to set a better example in our own work.
+	 */
+
+})( jQuery );

--- a/source-file-interceptor/public/partials/source-file-interceptor-public-display.php
+++ b/source-file-interceptor/public/partials/source-file-interceptor-public-display.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Provide a public-facing view for the plugin
+ *
+ * This file is used to markup the public-facing aspects of the plugin.
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ * @subpackage Source_File_Interceptor/public/partials
+ */
+?>
+
+<!-- This file should primarily consist of HTML with a little bit of PHP. -->

--- a/source-file-interceptor/source-file-interceptor.php
+++ b/source-file-interceptor/source-file-interceptor.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * The plugin bootstrap file
+ *
+ * This file is read by WordPress to generate the plugin information in the plugin
+ * admin area. This file also includes all of the dependencies used by the plugin,
+ * registers the activation and deactivation functions, and defines a function
+ * that starts the plugin.
+ *
+ * @link              https://example.com
+ * @since             1.0.0
+ * @package           Source_File_Interceptor
+ *
+ * @wordpress-plugin
+ * Plugin Name:       source-file-interceptor
+ * Plugin URI:        https://example.com
+ * Description:       This is a description of the plugin.
+ * Version:           1.0.0
+ * Author:            James O'Brien
+ * Author URI:        https://example.com/
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ * Text Domain:       source-file-interceptor
+ * Domain Path:       /languages
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * Currently plugin version.
+ * Start at version 1.0.0 and use SemVer - https://semver.org
+ * Rename this for your plugin and update it as you release new versions.
+ */
+define( 'SOURCE_FILE_INTERCEPTOR_VERSION', '1.0.0' );
+
+/**
+ * The code that runs during plugin activation.
+ * This action is documented in includes/class-source-file-interceptor-activator.php
+ */
+function activate_source_file_interceptor() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-source-file-interceptor-activator.php';
+	Source_File_Interceptor_Activator::activate();
+}
+
+/**
+ * The code that runs during plugin deactivation.
+ * This action is documented in includes/class-source-file-interceptor-deactivator.php
+ */
+function deactivate_source_file_interceptor() {
+	require_once plugin_dir_path( __FILE__ ) . 'includes/class-source-file-interceptor-deactivator.php';
+	Source_File_Interceptor_Deactivator::deactivate();
+}
+
+register_activation_hook( __FILE__, 'activate_source_file_interceptor' );
+register_deactivation_hook( __FILE__, 'deactivate_source_file_interceptor' );
+
+/**
+ * The core plugin class that is used to define internationalization,
+ * admin-specific hooks, and public-facing site hooks.
+ */
+require plugin_dir_path( __FILE__ ) . 'includes/class-source-file-interceptor.php';
+
+/**
+ * Begins execution of the plugin.
+ *
+ * Since everything within the plugin is registered via hooks,
+ * then kicking off the plugin from this point in the file does
+ * not affect the page life cycle.
+ *
+ * @since    1.0.0
+ */
+function run_source_file_interceptor() {
+
+	$plugin = new Source_File_Interceptor();
+	$plugin->run();
+
+}
+run_source_file_interceptor();
+
+function inject_source_ctx($parsed_args, $url) {
+    $e = new \Exception();
+	$traceString = $e->getTraceAsString();
+	$trace = preg_split("/\r\n|\n|\r/", $traceString);
+	foreach ($trace as $frame) {
+		$parts = explode(' ', $frame);
+		if (count($parts) < 3) {
+			continue;
+		}
+
+		$func = explode('(', $parts[2])[0];
+		if (str_starts_with($func, 'wp_remote')) {
+			error_log(var_export($trace, true));
+			$src = $parts[1];
+			$srcParts = explode('(', $src);
+			$srcFile = $srcParts[0];
+			$srcLine = explode(')', $srcParts[1])[0];
+			header("X-WP-Remote-Call: {$func}");
+			header("X-User-Agent: {$parsed_args['user-agent']}");
+			header("X-Request-URI: {$url}");
+			header("X-Request-Method: {$_SERVER['REQUEST_METHOD']}");
+			header("X-Source-File: {$srcFile}");
+			header("X-Source-Line: {$srcLine}");
+
+
+			error_log("Detected call to {$func} in file {$srcFile}, line {$srcLine}");
+		}
+	}
+	return $parsed_args;
+}
+
+add_filter('http_request_args', 'inject_source_ctx', 10, 3);

--- a/source-file-interceptor/source-file-interceptor.php
+++ b/source-file-interceptor/source-file-interceptor.php
@@ -82,6 +82,10 @@ function run_source_file_interceptor() {
 run_source_file_interceptor();
 
 function inject_source_ctx($parsed_args, $url) {
+	if (str_starts_with($url, $_ENV['ELASTICSEARCH_URL'])) {
+		return $parsed_args;
+	}
+
     $e = new \Exception();
 	$traceString = $e->getTraceAsString();
 	$trace = preg_split("/\r\n|\n|\r/", $traceString);
@@ -105,11 +109,37 @@ function inject_source_ctx($parsed_args, $url) {
 			header("X-Source-File: {$srcFile}");
 			header("X-Source-Line: {$srcLine}");
 
+			$dt = new DateTime();
+			$iso8601 = $dt->format(DateTime::ATOM);
+			$payload = array(
+				'wp_remote_func' => $func,
+				'request_uri' => $url,
+				'method' => $parsed_args['method'],
+				'source_file' => $srcFile,
+				'source_line' => $srcLine,
+				'timestamp' => $iso8601,
+			);
 
 			error_log("Detected call to {$func} in file {$srcFile}, line {$srcLine}");
+
+
+
+			$res = wp_remote_post(
+				"{$_ENV['ELASTICSEARCH_URL']}/api-calls/_doc",
+				array (
+					'headers' => array('Content-Type' => 'application/json; charset=utf-8'),
+					'body' => json_encode($payload),
+					'method' => 'POST',
+					'data_format' => 'body',
+				)
+			);
+			error_log(var_export($res, true));
 		}
 	}
+
+
+
 	return $parsed_args;
 }
 
-add_filter('http_request_args', 'inject_source_ctx', 10, 3);
+add_filter('http_request_args', 'inject_source_ctx', 999, 3);

--- a/source-file-interceptor/uninstall.php
+++ b/source-file-interceptor/uninstall.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Fired when the plugin is uninstalled.
+ *
+ * When populating this file, consider the following flow
+ * of control:
+ *
+ * - This method should be static
+ * - Check if the $_REQUEST content actually is the plugin name
+ * - Run an admin referrer check to make sure it goes through authentication
+ * - Verify the output of $_GET makes sense
+ * - Repeat with other user roles. Best directly by using the links/query string parameters.
+ * - Repeat things for multisite. Once for a single site in the network, once sitewide.
+ *
+ * This file may be updated more in future version of the Boilerplate; however, this is the
+ * general skeleton and outline for how the file should work.
+ *
+ * For more information, see the following discussion:
+ * https://github.com/tommcfarlin/WordPress-Plugin-Boilerplate/pull/123#issuecomment-28541913
+ *
+ * @link       https://example.com
+ * @since      1.0.0
+ *
+ * @package    Source_File_Interceptor
+ */
+
+// If uninstall not called from WordPress, then exit.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}


### PR DESCRIPTION
This changeset adds Elasticsearch and Kibana to the fakewoo setup, for storing and searching outgoing HTTP requests

Due to the fact that tcpdump cannot inspect the contents of encrypted requests, the processing is now done via the `http_request_args` hook provided by WordPress. As such, it can only inspect HTTP requests made via the WordPress HTTP API (e.g. `wp_remote_*`). Requests from other HTTP APIs may not be captured.